### PR TITLE
Fix icons and objects which shouldn't be selectable

### DIFF
--- a/navigation.css
+++ b/navigation.css
@@ -153,6 +153,8 @@
     padding: 5px 10px;
 
     cursor: pointer;
+
+    user-select: none;
 }
 
 .pmSettingsBtn p{
@@ -207,6 +209,8 @@
 
     font-size: 25px;
     font-family: FLNTREG;
+
+    user-select: none;
 }
 
 .sbButton:hover{


### PR DESCRIPTION
this fixes selecting the home & settings button, which in my opinion shouldn't happen (icons not text)